### PR TITLE
Fix error message 'uninitialized constant LegacyMigrations::StatusReport' when running a migration

### DIFF
--- a/lib/legacy_migrations.rb
+++ b/lib/legacy_migrations.rb
@@ -2,6 +2,7 @@ require 'legacy_migrations/transformations'
 require 'legacy_migrations/future_storage'
 require 'legacy_migrations/squirrel'
 require 'legacy_migrations/source_iterators'
+require 'legacy_migrations/status_report'
 require 'legacy_migrations/row_matchers'
 module LegacyMigrations
 


### PR DESCRIPTION
When using this gem, as the README outlines, I have been seeing the error message

```
uninitialized constant LegacyMigrations::StatusReport
```

This commit adds a require for the status_report.rb file and seems to fix the problem.
